### PR TITLE
Validate score positions

### DIFF
--- a/app/admin/scores.rb
+++ b/app/admin/scores.rb
@@ -3,9 +3,15 @@ ActiveAdmin.register Score do
 
   form do |f|
     f.inputs do
-      input :congress_member_id, as: :select,
-                                 collection: CongressMember.current.without_scores
-      input :position
+      input :congress_member_id,
+        as: :select,
+        collection: CongressMember.current.without_scores,
+        include_blank: false
+      input :position,
+        as: :select,
+        collection: Score::POSITIONS,
+        default: Score::DEFAULT_POSITION,
+        include_blank: false
       input :source_url
     end
 

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -1,6 +1,14 @@
 class Score < ApplicationRecord
+  DEFAULT_POSITION = "Uncommitted"
+  POSITIONS = (%w(Yes No) << DEFAULT_POSITION).freeze
+
   belongs_to :congress_member
   validates_uniqueness_of :congress_member
+  validates_inclusion_of :position, in: POSITIONS
+
+  def repair_position
+    update_attribute(:position, DEFAULT_POSITION) unless POSITIONS.include?(position)
+  end
 
   def self.lookup(state, district)
     all.includes(:congress_member).merge(CongressMember.lookup(state, district))

--- a/db/migrate/20180223012332_add_default_position_to_score.rb
+++ b/db/migrate/20180223012332_add_default_position_to_score.rb
@@ -1,0 +1,13 @@
+class AddDefaultPositionToScore < ActiveRecord::Migration[5.1]
+  def up
+    change_column :scores, :position, :string, default: Score::DEFAULT_POSITION
+
+    Score.where.not(position: Score::POSITIONS).find_each do |score|
+      score.repair_position
+    end
+  end
+
+  def down
+    change_column :scores, :position, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222203922) do
+ActiveRecord::Schema.define(version: 20180223012332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20180222203922) do
   end
 
   create_table "scores", force: :cascade do |t|
-    t.string "position"
+    t.string "position", default: "Uncommitted"
     t.string "source_url"
     t.bigint "congress_member_id"
     t.index ["congress_member_id"], name: "index_scores_on_congress_member_id"

--- a/spec/helpers/tweet_helper_spec.rb
+++ b/spec/helpers/tweet_helper_spec.rb
@@ -17,7 +17,7 @@ describe TweetHelper do
   end
 
   describe '#tweet_message' do
-    let(:position) { 'anything besides yes or no' }
+    let(:position) { Score::DEFAULT_POSITION }
     let(:handle) { '@RepRaptor' }
     let(:score) { FactoryBot.create(:score, position: position) }
     let(:website) { 'https://checkyourreps.org' }

--- a/spec/models/score_spec.rb
+++ b/spec/models/score_spec.rb
@@ -1,6 +1,43 @@
 require "rails_helper"
 
 RSpec.describe Score, type: :model do
+  describe 'validations' do
+    subject(:score) { FactoryBot.build(:score) }
+
+    context 'with an invalid position' do
+      before { score.position = 'some nonsense' }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'with an valid position' do
+      before { score.position = Score::POSITIONS.sample }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe '.repair_position' do
+    subject(:score) { FactoryBot.build(:score, position: position) }
+
+    context 'if position is valid' do
+      let(:position) { Score::POSITIONS.sample }
+
+      it 'does nothing' do
+        expect { score.repair_position }.not_to change(score, :position)
+      end
+    end
+
+    context 'if position is invalid' do
+      let(:position) { 'some nonsense' }
+
+      it "sets the position to 'Uncommitted'" do
+        expect { score.repair_position }.to change(score, :position)
+        expect(score.reload.position).to eq(Score::DEFAULT_POSITION)
+      end
+    end
+  end
+
   describe "self.lookup" do
     let(:score) do
       FactoryBot.create(:score, congress_member: FactoryBot.create(:senator,


### PR DESCRIPTION
* Positions must be "Yes", "No", or "Uncommitted"
* The column now defaults to "Uncommitted"
* As part of the migration, invalid positions will be reset to "Uncommitted"
* Invalid models can be repaired with `.repair_position`
* Admins can only select score position from a valid list

https://github.com/EFForg/check-your-reps/issues/58