### PR TITLE
Editing a score shouldn't reset the congress member

### DIFF
--- a/app/admin/scores.rb
+++ b/app/admin/scores.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Score do
     f.inputs do
       input :congress_member_id,
         as: :select,
-        collection: CongressMember.current.without_scores,
+        collection: (object.persisted? ? CongressMember.current : CongressMember.current.without_scores),
         include_blank: false
       input :position,
         as: :select,


### PR DESCRIPTION
https://github.com/EFForg/check-your-reps/issues/61
In order to make it easier to populate scores, we restricted the list of congress members to those without scores.  However, that meant that when an existing score was edited, its congress member was no longer available.  Whoops!