### PR TITLE
Fix tablesort on initial visit

### DIFF
--- a/app/assets/javascripts/application/scorecard.js
+++ b/app/assets/javascripts/application/scorecard.js
@@ -1,7 +1,7 @@
 //= require tablesort/dist/tablesort.min.js
 
 /* global Tablesort */
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
   const table = document.getElementById('all-congress-members-table');
   if (table) { Tablesort(table); }
 });


### PR DESCRIPTION
https://github.com/EFForg/check-your-reps/issues/90
Rails 5 uses Turbolinks to speed up navigation, fine, good, but Turbolinks uses fanciness to avoid loading scripts that are not present on the initial page load.  This lead to the tablesort working when the page was reloaded, but not when navigating from another page.