### PR TITLE
Center smarty-streets link

### DIFF
--- a/app/assets/stylesheets/components/homepage.scss
+++ b/app/assets/stylesheets/components/homepage.scss
@@ -38,10 +38,7 @@
     font-size: 0.6rem;
     line-height: 0.6rem;
     margin: -0.5rem auto 2rem;
-    width: 100%;
-    @include breakpoint(medium) {
-      width: 18rem;
-    }
+    text-align: center;
   }
   iframe {
     display: block;


### PR DESCRIPTION
https://github.com/EFForg/check-your-reps/issues/112

This does not fix an existing bug where the tooltip goes off the right side of the page on medium-sized screens.