### PR TITLE
Add monitoring with Sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ smarty_streets_token=
 # RAILS_SERVE_STATIC_FILES=true
 # SECRET_KEY_BASE=
 # DEVISE_SECRET_KEY=
+
+# Error reporting
+# SENTRY_DSN=
+# SENTRY_PUBLIC_DSN=

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem "pg", "~> 0.18"
 gem "puma", "~> 3.7"
 gem "rails", "~> 5.1.4"
 
+# Error reporting
+gem "sentry-raven"
+
 # Use SCSS for stylesheets
 gem "foundation-rails", ">= 6" # Use Foundation for grids and other styles
 gem "sass-rails", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     factory_bot_rails (4.8.2)
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
+    faraday (0.14.0)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -172,6 +174,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
     netrc (0.11.0)
     nio4r (2.2.0)
     nokogiri (1.8.2)
@@ -271,6 +274,8 @@ GEM
     selenium-webdriver (3.8.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    sentry-raven (2.7.2)
+      faraday (>= 0.7.6, < 1.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -339,6 +344,7 @@ DEPENDENCIES
   rubocop-github
   sass-rails (~> 5.0)
   selenium-webdriver
+  sentry-raven
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+if ENV["SENTRY_DSN"].present?
+  Raven.configure do |config|
+    config.dsn = ENV["SENTRY_DSN"]
+  end
+end


### PR DESCRIPTION
Cleans up the Gemfile a bit and adds the sentry-raven gem for error monitoring. We'll need to update .env at deploy time.

Closes #8 