### PR TITLE
Invite admins with Devise

### DIFF
--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -26,4 +26,25 @@ ActiveAdmin.register AdminUser do
     f.actions
   end
 
+  batch_action :invite, :method => :post do |ids|
+    successes = []
+    errors = []
+
+    AdminUser.where(id: ids).each do |user|
+      user.invite!(current_admin_user)
+
+      if user.errors.empty?
+        successes << user.email
+      else
+        messages = user.errors.full_messages.map { |msg| msg }.join
+        errors << "#{user.email} was not invited: #{messages}"
+      end
+    end
+
+    alert = ''
+    alert += "The following admins were successfully invited: #{successes.join(", ")}" if successes.present?
+    alert += "\n #{errors.join("\n")}" if errors.present?
+
+    redirect_to admin_admin_users_path, alert: alert
+  end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -2,6 +2,6 @@
 class AdminUser < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable,
+  devise :database_authenticatable, :invitable,
          :recoverable, :rememberable, :trackable, :validatable
 end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,20 @@
+<div class="row align-center">
+  <div class="large-8 medium-10 small-11 columns">
+    <h2><%= t 'devise.invitations.edit.header' %></h2>
+
+    <%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f| %>
+      <%= devise_error_messages! %>
+      <%= f.hidden_field :invitation_token %>
+
+      <% if f.object.class.require_password_on_accepting %>
+      <p><%= f.label :password %><br />
+      <%= f.password_field :password %></p>
+
+      <p><%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation %></p>
+      <% end %>
+
+      <p><%= f.submit t("devise.invitations.edit.submit_button") %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,16 @@
+<div class="row align-center">
+  <div class="large-8 medium-10 small-11 columns">
+    <h2><%= t "devise.invitations.new.header" %></h2>
+
+    <%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f| %>
+      <%= devise_error_messages! %>
+
+    <% resource.class.invite_key_fields.each do |field| -%>
+      <p><%= f.label field %><br />
+      <%= f.text_field field %></p>
+    <% end -%>
+
+      <p><%= f.submit t("devise.invitations.new.submit_button") %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,17 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p>
+  <% if @resource.persisted? %>
+    <%= t("devise.mailer.invitation_instructions.ignore_persisted").html_safe %>
+  <% else %>
+    <%= t("devise.mailer.invitation_instructions.ignore").html_safe %>
+  <% end %>
+</p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,0 +1,15 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, :invitation_token => @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<% if @resource.persisted? %>
+  <%= strip_tags t("devise.mailer.invitation_instructions.ignore_persisted") %>
+<% else %>
+  <%= strip_tags t("devise.mailer.invitation_instructions.ignore") %>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,10 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "check-your-reps_#{Rails.env}"
   config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { host: Rails.application.secrets.smtp_domain, protocol: 'https' }
+  config.action_mailer.asset_host = "https://#{Rails.application.secrets.smtp_domain}"
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'do-not-reply@eff.org'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -117,6 +117,54 @@ Devise.setup do |config|
 
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
+
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid, after
+  # this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  # config.invite_for = 2.weeks
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = {:email => /\A[^@]+@[^@]+\z/}
+  # config.invite_key = {:email => /\A[^@]+@[^@]+\z/, :username => nil}
+
+  # Flag that force a record to be valid before being actually invited
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,32 @@
+en:
+  devise:
+    failure:
+      invited: "You have a pending invitation, accept it to finish creating your account."
+    invitations:
+      send_instructions: "An invitation email has been sent to %{email}."
+      invitation_token_invalid: "The invitation token provided is not valid!"
+      updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: "Your invitation was removed."
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: "Invitation instructions"
+        hello: "Hello %{email}"
+        someone_invited_you: "Someone has invited you to %{url}. You can accept it through the link below."
+        accept: "Accept invitation"
+        accept_until: "This invitation will be due in %{due_date}."
+        ignore: "If you don't want to accept the invitation, please ignore this email.<br />\nYour account won't be created until you access the link above and set your password."
+        ignore_persisted: "If you don't want to accept the invitation, please ignore this email."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/db/migrate/20180307222753_devise_invitable_add_to_admin_users.rb
+++ b/db/migrate/20180307222753_devise_invitable_add_to_admin_users.rb
@@ -1,0 +1,23 @@
+class DeviseInvitableAddToAdminUsers < ActiveRecord::Migration[5.1]
+  def up
+    change_table :admin_users do |t|
+      t.string     :invitation_token
+      t.datetime   :invitation_created_at
+      t.datetime   :invitation_sent_at
+      t.datetime   :invitation_accepted_at
+      t.integer    :invitation_limit
+      t.references :invited_by, polymorphic: true
+      t.integer    :invitations_count, default: 0
+      t.index      :invitations_count
+      t.index      :invitation_token, unique: true # for invitable
+      t.index      :invited_by_id
+    end
+  end
+
+  def down
+    change_table :admin_users do |t|
+      t.remove_references :invited_by, polymorphic: true
+      t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180223012332) do
+ActiveRecord::Schema.define(version: 20180307222753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,19 @@ ActiveRecord::Schema.define(version: 20180223012332) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.bigint "invited_by_id"
+    t.integer "invitations_count", default: 0
     t.index ["email"], name: "index_admin_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_admin_users_on_invitation_token", unique: true
+    t.index ["invitations_count"], name: "index_admin_users_on_invitations_count"
+    t.index ["invited_by_id"], name: "index_admin_users_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_admin_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
https://github.com/EFForg/check-your-reps/issues/75

This is the Rails piece. In order to actually deliver emails, we need to set up the production environment.  That might be as simple as adding STMP credentials like the Action Center or SEC have, but I'm not really sure.

Admins can be invited through the admin interface:
<img width="294" alt="screen shot 2018-03-07 at 7 17 20 pm" src="https://user-images.githubusercontent.com/1065956/37131215-385cf2d0-223c-11e8-8719-e19844dc5ae1.png">

That action creates an email like the following:
<img width="639" alt="screen shot 2018-03-07 at 7 20 56 pm" src="https://user-images.githubusercontent.com/1065956/37131316-b40c2126-223c-11e8-994a-85320744e929.png">

Following the link in the email takes you to a page that looks like this:
<img width="1092" alt="screen shot 2018-03-07 at 7 14 56 pm" src="https://user-images.githubusercontent.com/1065956/37131163-00945082-223c-11e8-95eb-50b48f690c6a.png">
