### PR TITLE
Send mail in production via ssmtp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,6 @@ node_modules/
 pgdata/
 public/uploads
 files
+
+# Ignore the dockerfile itself
+Dockerfile

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ smarty_streets_token=
 # RAILS_ENV=production
 # RAILS_LOG_TO_STDOUT=true
 # RAILS_SERVE_STATIC_FILES=true
+# SERVER_HOST=https://checkyourreps.org
 # SECRET_KEY_BASE=
 # DEVISE_SECRET_KEY=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.5-alpine
 RUN mkdir -p /opt/check-your-reps
 WORKDIR /opt/check-your-reps
 
-RUN adduser -DS -h /opt/trainers-hub www-data;
+RUN adduser -DS -h /opt/check-your-reps www-data;
 
 RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >>/etc/apk/repositories \
   && apk upgrade --update-cache \
@@ -14,7 +14,9 @@ RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >>/etc/apk/repositor
     postgresql-dev \
     postgresql-client \
     nodejs \
-    yarn
+    yarn \
+    ssmtp \
+  && echo "www-data:no-reply@eff.org:mail2.eff.org:587" > /etc/ssmtp/revaliases
 
 COPY Gemfile* ./
 RUN bundle install

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,9 +60,11 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "check-your-reps_#{Rails.env}"
   config.action_mailer.perform_caching = false
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { host: Rails.application.secrets.smtp_domain, protocol: 'https' }
-  config.action_mailer.asset_host = "https://#{Rails.application.secrets.smtp_domain}"
+  config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.default_url_options = {
+    host: ENV["SERVER_HOST"],
+    protocol: "https"
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
Sets up production email via eff's e-mail server.

The from field will show "Linux User" because Alpine doesn't come with chfn to change the user's full name. If we start sending e-mail to more than a couple staff members, we can add the `shadow` package to make that prettier.